### PR TITLE
Replacing deprecated autofill field names

### DIFF
--- a/form-cc-example-m.html
+++ b/form-cc-example-m.html
@@ -70,12 +70,12 @@
           <div class="form-group">
             <label for="frmCityS" class="active col-lg-2 control-label">City</label>
             <div class="col-lg-10">
-              <input name="ship-city" class="form-control validate" required id="frmCityS" placeholder="New York" autocomplete="shipping locality"></div>
+              <input name="ship-city" class="form-control validate" required id="frmCityS" placeholder="New York" autocomplete="shipping address-level2"></div>
           </div>
           <div class="form-group">
             <label for="frmStateS" class="active col-lg-2 control-label">State</label>
             <div class="col-lg-10">
-              <input name="ship-state" class="form-control validate" required id="frmStateS" placeholder="NY" autocomplete="shipping region"></div>
+              <input name="ship-state" class="form-control validate" required id="frmStateS" placeholder="NY" autocomplete="shipping address-level1"></div>
           </div>
 
           <div class="form-group">

--- a/form-cc-example-m2.html
+++ b/form-cc-example-m2.html
@@ -107,12 +107,12 @@
           <div class="form-group">
             <label for="frmCityS" class="active col-lg-2 control-label">City</label>
             <div class="col-lg-10">
-              <input name="ship-city" class="form-control validate" required id="frmCityS" placeholder="New York" autocomplete="shipping locality"></div>
+              <input name="ship-city" class="form-control validate" required id="frmCityS" placeholder="New York" autocomplete="shipping address-level2"></div>
           </div>
           <div class="form-group">
             <label for="frmStateS" class="active col-lg-2 control-label">State</label>
             <div class="col-lg-10">
-              <input name="ship-state" class="form-control validate" required id="frmStateS" placeholder="NY" autocomplete="shipping region"></div>
+              <input name="ship-state" class="form-control validate" required id="frmStateS" placeholder="NY" autocomplete="shipping address-level1"></div>
           </div>
 
           <div class="form-group">

--- a/form-cc-example.html
+++ b/form-cc-example.html
@@ -86,9 +86,9 @@
               <label for="frmAddressS">Address</label>
               <input name="ship-address" required id="frmAddressS" placeholder="123 Any Street" autocomplete="shipping street-address">
               <label for="frmCityS">City</label>
-              <input name="ship-city" required id="frmCityS" placeholder="New York" autocomplete="shipping locality">
+              <input name="ship-city" required id="frmCityS" placeholder="New York" autocomplete="shipping address-level2">
               <label for="frmStateS">State</label>
-              <input name="ship-state" required id="frmStateS" placeholder="NY" autocomplete="shipping region">
+              <input name="ship-state" required id="frmStateS" placeholder="NY" autocomplete="shipping address-level1">
               <label for="frmZipS">Zip</label>
               <input name="ship-zip" required id="frmZipS" placeholder="10011" autocomplete="shipping postal-code">
               <label for="frmCountryS">Country</label>
@@ -103,9 +103,9 @@
               <label for="frmAddressB">Address</label>
               <input name="bill-address" id="frmAddressB" required placeholder="123 Any Street" autocomplete="billing street-address">
               <label for="frmCityB">City</label>
-              <input name="bill-city" id="frmCityB" required placeholder="New York" autocomplete="billing locality">
+              <input name="bill-city" id="frmCityB" required placeholder="New York" autocomplete="billing address-level2">
               <label for="frmStateB">State</label>
-              <input name="bill-state" id="frmStateB" required placeholder="NY" autocomplete="billing region">
+              <input name="bill-state" id="frmStateB" required placeholder="NY" autocomplete="billing address-level1">
               <label for="frmZipB">Zip</label>
               <input name="bill-zip" id="frmZipB" required placeholder="10011" autocomplete="billing postal-code">
               <label for="frmCountryB">Country</label>


### PR DESCRIPTION
I'm conducting research on how browsers support autofill. I've been referencing your post on Google Developers which is excellent. Unfortunately, it looks like the locality and region autofill field names have been deprecated.
